### PR TITLE
Added MonadUnliftIO instance

### DIFF
--- a/monad-logger-prefix.cabal
+++ b/monad-logger-prefix.cabal
@@ -37,6 +37,7 @@ library
       , transformers-base >= 0.4     && < 0.5
       , text              >= 1.1     && < 1.3
       , resourcet         >= 1.1     && < 1.3
+      , unliftio-core     >= 0.1.1   && < 0.2
     exposed-modules:
         Control.Monad.Logger.Prefix
     default-language: 

--- a/monad-logger-prefix.cabal
+++ b/monad-logger-prefix.cabal
@@ -37,7 +37,8 @@ library
       , transformers-base >= 0.4     && < 0.5
       , text              >= 1.1     && < 1.3
       , resourcet         >= 1.1     && < 1.3
-      , unliftio-core     >= 0.1.1   && < 0.2
+      -- Control.Monad.Logger also leaves this unbounded.
+      , unliftio-core
     exposed-modules:
         Control.Monad.Logger.Prefix
     default-language: 


### PR DESCRIPTION
This is supported in the base `Control.Monad.Logger` library, and I can't see any particular reason not to support it here.

You might also want to consider exporting the constructor of `LogPrefixT` so that these sorts of things can be constructed on-site when needed.